### PR TITLE
Move vertical above horizontal in both lib and spec files

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -47,16 +47,16 @@ class Board
     split_coord(coordinates, index).uniq.length == 1
   end
 
-  def is_horizontal?(ship, coordinates)
-    range = split_coord(coordinates, 1)[0]..split_coord(coordinates, 1)[-1]
-    numbers_check = split_coord(coordinates, 1) == range.to_a
-    uniq_size?(coordinates, 0) && numbers_check
-  end
-
   def is_vertical?(ship, coordinates)
     range = split_coord(coordinates, 0)[0]..split_coord(coordinates, 0)[-1]
     letters_check = split_coord(coordinates, 0) == range.to_a
     uniq_size?(coordinates, 1) && letters_check
+  end
+
+  def is_horizontal?(ship, coordinates)
+    range = split_coord(coordinates, 1)[0]..split_coord(coordinates, 1)[-1]
+    numbers_check = split_coord(coordinates, 1) == range.to_a
+    uniq_size?(coordinates, 0) && numbers_check
   end
 
   def place(ship, coordinates)

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -84,15 +84,6 @@ describe Board do
     expect(board.uniq_size?(["A1", "A2"], 1)).to eq(false)
   end
 
-  it 'is horizontal' do
-    board = Board.new
-    cruiser = Ship.new("Cruiser", 3)
-    submarine = Ship.new("Submarine", 2)
-
-    expect(board.is_horizontal?(submarine, ["A1", "A2"])).to eq(true)
-    expect(board.is_horizontal?(cruiser, ["A1", "B1", "C1"])).to eq(false)
-  end
-
   it 'is vertical' do
     board = Board.new
     cruiser = Ship.new("Cruiser", 3)
@@ -100,6 +91,15 @@ describe Board do
 
     expect(board.is_vertical?(submarine, ["A1", "B1"])).to eq(true)
     expect(board.is_vertical?(cruiser, ["A1", "A2", "A3"])).to eq(false)
+  end
+
+  it 'is horizontal' do
+    board = Board.new
+    cruiser = Ship.new("Cruiser", 3)
+    submarine = Ship.new("Submarine", 2)
+
+    expect(board.is_horizontal?(submarine, ["A1", "A2"])).to eq(true)
+    expect(board.is_horizontal?(cruiser, ["A1", "B1", "C1"])).to eq(false)
   end
 
   it 'can place a ship' do
@@ -156,10 +156,6 @@ describe Board do
                   "D . . . . \n"
     board.place(cruiser, ["A1", "A2", "A3"])
 
-    expect(board.render(true)).to eq("   1 2 3 4 \n" +
-                                      "A S S S . \n" +
-                                      "B . . . . \n" +
-                                      "C . . . . \n" +
-                                      "D . . . . \n")
+    expect(board.render(true)).to eq(user_board)
   end
 end


### PR DESCRIPTION
It might make sense to move the `is_vertical?` method above the `is_horizontal?` method since the coordinates read letter to number, and the index will be 0 to reference the letter and 1 to reference the number after the coordinates are split. I moved the tests in the spec file too, just to be consistent. 